### PR TITLE
test: parse zodiac birthdates as ISO dates and add tests

### DIFF
--- a/packages/batch-prepare/src/batch_prepare_input.py
+++ b/packages/batch-prepare/src/batch_prepare_input.py
@@ -12,7 +12,7 @@ This module prepares JSONL files for OpenAI batch processing by:
 import json
 import sys
 import uuid
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Optional, Tuple
 
 from shared.config import (
@@ -37,17 +37,15 @@ def get_zodiac_sign(birthdate: str) -> str:
     Determine zodiac sign based on birthdate.
 
     Args:
-        birthdate (str): Birthdate in MM/DD/YYYY format.
+        birthdate (str): Birthdate in ISO ``YYYY-MM-DD`` format.
 
     Returns:
         str: The zodiac sign or "Unknown" if parsing fails.
     """
     try:
-        month_str = birthdate[0:2]  # Extract "MM" part
-        day_str = birthdate[3:5]    # Extract "DD" part
-
-        month = int(month_str)
-        day = int(day_str)
+        parsed = datetime.strptime(birthdate, "%Y-%m-%d").date()
+        month = parsed.month
+        day = parsed.day
 
         zodiac = [
             ((1, 20), "Aquarius"), ((2, 19), "Pisces"), ((3, 21), "Aries"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration: make the batch-prepare source importable.
+
+The package directory name contains a hyphen, so it is not importable as a
+normal package. We add its ``src`` directory (and the repo root, for the
+``shared`` package) to ``sys.path``.
+"""
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BATCH_PREPARE_SRC = os.path.join(
+    REPO_ROOT, "packages", "batch-prepare", "src"
+)
+
+for path in (REPO_ROOT, BATCH_PREPARE_SRC):
+    if path not in sys.path:
+        sys.path.insert(0, path)

--- a/tests/test_get_zodiac_sign.py
+++ b/tests/test_get_zodiac_sign.py
@@ -1,0 +1,36 @@
+"""Tests for get_zodiac_sign, which expects ISO YYYY-MM-DD birth dates."""
+import pytest
+from batch_prepare_input import get_zodiac_sign
+
+
+@pytest.mark.parametrize(
+    "birthdate,expected",
+    [
+        ("2001-09-03", "Virgo"),    # Blanka Vas
+        ("1998-09-21", "Virgo"),    # Tadej Pogačar
+        ("1986-05-25", "Gemini"),   # Geraint Thomas (day > 12)
+        ("2002-01-13", "Capricorn"),
+        # Cusp boundaries
+        ("2000-01-20", "Aquarius"),  # first day of Aquarius
+        ("2000-01-19", "Capricorn"),  # last day of Capricorn
+        ("2000-12-22", "Capricorn"),  # first day of Capricorn
+        ("2000-12-21", "Sagittarius"),  # last day of Sagittarius
+    ],
+)
+def test_returns_correct_sign(birthdate: str, expected: str) -> None:
+    """A valid ISO birthdate maps to the correct zodiac sign."""
+    assert get_zodiac_sign(birthdate) == expected
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "garbage",
+        "03.09.2001",   # old DD.MM.YYYY format is no longer accepted
+        "2001/09/03",
+        "",
+    ],
+)
+def test_unparseable_returns_unknown(bad: str) -> None:
+    """An unparseable birthdate string yields "Unknown"."""
+    assert get_zodiac_sign(bad) == "Unknown"


### PR DESCRIPTION
## Summary
- Switch `get_zodiac_sign` to `datetime.strptime` with the ISO `YYYY-MM-DD` format instead of slicing an assumed `MM/DD/YYYY` string, fixing incorrect signs for ISO-formatted `birth_date` values from `riders.json`.
- Add a pytest suite covering correct signs, cusp boundaries (e.g. first/last day of each sign), and unparseable inputs (returning `"Unknown"`).
- `tests/conftest.py` puts the hyphenated `batch-prepare/src` dir and the repo root on `sys.path` so the entrypoint module and the `shared` package import in tests.

## Test plan
- All `get_zodiac_sign` cases verified (signs, cusp boundaries, and unparseable inputs return `"Unknown"`).
- flake8 / isort / mypy / bandit run clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)